### PR TITLE
fix: bind Windows camera names to probed indices

### DIFF
--- a/ui/gui_startup.py
+++ b/ui/gui_startup.py
@@ -1,10 +1,16 @@
 ﻿# ui/gui_startup.py
 from __future__ import annotations
 
-import sys
 import argparse
+import contextlib
+import json
+import platform
+import re
+import subprocess
+import sys
 from dataclasses import dataclass, field
-from typing import Dict, List, Any
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Tuple
 
 try:
     import tkinter as tk
@@ -18,10 +24,470 @@ except Exception:
 class FieldSpec:
     key: str
     label: str
-    type: str  # 'str'|'int'|'float'|'bool'|'choice'|'file'
+    type: str  # 'str'|'int'|'float'|'bool'|'choice'|'file'|'camera'
     default: object
     choices: List[object] = field(default_factory=list)
     help: str = ""
+
+
+def _enumerate_cameras_linux() -> List[Tuple[int, str]]:
+    devices: List[Tuple[int, str]] = []
+    sys_class = Path("/sys/class/video4linux")
+    if sys_class.exists():
+        def sort_key(path: Path) -> int:
+            match = re.search(r"(\d+)$", path.name)
+            return int(match.group(1)) if match else sys.maxsize
+
+        for entry in sorted(sys_class.glob("video*"), key=sort_key):
+            match = re.search(r"(\d+)$", entry.name)
+            if not match:
+                continue
+            idx = int(match.group(1))
+            name_path = entry / "name"
+            try:
+                name = name_path.read_text(encoding="utf-8").strip()
+            except OSError:
+                name = entry.name
+            devices.append((idx, name))
+    if devices:
+        return devices
+
+    dev_dir = Path("/dev")
+    if dev_dir.exists():
+        def dev_sort_key(path: Path) -> int:
+            match = re.search(r"(\d+)$", path.name)
+            return int(match.group(1)) if match else sys.maxsize
+
+        for entry in sorted(dev_dir.glob("video*"), key=dev_sort_key):
+            match = re.search(r"(\d+)$", entry.name)
+            if not match:
+                continue
+            idx = int(match.group(1))
+            devices.append((idx, entry.name))
+    return devices
+
+
+def _extract_windows_pnp_id(display_name: str) -> str | None:
+    prefix = "@device:pnp:"
+    if not display_name.lower().startswith(prefix):
+        return None
+
+    remainder = display_name[len(prefix):]
+    remainder = remainder.split("#{", 1)[0]
+    remainder = remainder.rstrip("\\")
+    if remainder.startswith("\\\\?\\"):
+        remainder = remainder[4:]
+    remainder = remainder.replace("#", "\\")
+    remainder = remainder.replace("\\\\", "\\")
+    remainder = remainder.strip("\\")
+    if not remainder:
+        return None
+    return remainder.upper()
+
+
+def _win32_directshow_display_names() -> List[str]:
+    try:
+        import ctypes
+        from ctypes import wintypes
+    except Exception:
+        return []
+
+    HRESULT = ctypes.c_long
+
+    class GUID(ctypes.Structure):
+        _fields_ = [
+            ("Data1", wintypes.DWORD),
+            ("Data2", wintypes.WORD),
+            ("Data3", wintypes.WORD),
+            ("Data4", ctypes.c_ubyte * 8),
+        ]
+
+        def __init__(self, value: str):  # type: ignore[override]
+            super().__init__()
+            value = value.strip("{}")
+            parts = value.split("-")
+            if len(parts) != 5:
+                raise ValueError(f"Invalid GUID string: {value}")
+            self.Data1 = int(parts[0], 16)
+            self.Data2 = int(parts[1], 16)
+            self.Data3 = int(parts[2], 16)
+            data4 = bytes.fromhex(parts[3] + parts[4])
+            for i in range(8):
+                self.Data4[i] = data4[i]
+
+    CLSID_SystemDeviceEnum = GUID("{62BE5D10-60EB-11d0-BD3B-00A0C911CE86}")
+    CLSID_VideoInputDeviceCategory = GUID("{860BB310-5D01-11d0-BD3B-00A0C911CE86}")
+    IID_ICreateDevEnum = GUID("{29840822-5B84-11D0-BD3B-00A0C911CE86}")
+
+    class ICreateDevEnum(ctypes.Structure):
+        pass
+
+    class IEnumMoniker(ctypes.Structure):
+        pass
+
+    class IMoniker(ctypes.Structure):
+        pass
+
+    class ICreateDevEnumVtbl(ctypes.Structure):
+        _fields_ = [
+            ("QueryInterface", ctypes.c_void_p),
+            ("AddRef", ctypes.c_void_p),
+            ("Release", ctypes.c_void_p),
+            ("CreateClassEnumerator", ctypes.c_void_p),
+        ]
+
+    class IEnumMonikerVtbl(ctypes.Structure):
+        _fields_ = [
+            ("QueryInterface", ctypes.c_void_p),
+            ("AddRef", ctypes.c_void_p),
+            ("Release", ctypes.c_void_p),
+            ("Next", ctypes.c_void_p),
+            ("Skip", ctypes.c_void_p),
+            ("Reset", ctypes.c_void_p),
+            ("Clone", ctypes.c_void_p),
+        ]
+
+    class IMonikerVtbl(ctypes.Structure):
+        _fields_ = [
+            ("QueryInterface", ctypes.c_void_p),
+            ("AddRef", ctypes.c_void_p),
+            ("Release", ctypes.c_void_p),
+            ("GetClassID", ctypes.c_void_p),
+            ("IsDirty", ctypes.c_void_p),
+            ("Load", ctypes.c_void_p),
+            ("Save", ctypes.c_void_p),
+            ("GetSizeMax", ctypes.c_void_p),
+            ("BindToObject", ctypes.c_void_p),
+            ("BindToStorage", ctypes.c_void_p),
+            ("Reduce", ctypes.c_void_p),
+            ("ComposeWith", ctypes.c_void_p),
+            ("Enum", ctypes.c_void_p),
+            ("IsEqual", ctypes.c_void_p),
+            ("Hash", ctypes.c_void_p),
+            ("IsRunning", ctypes.c_void_p),
+            ("GetTimeOfLastChange", ctypes.c_void_p),
+            ("Inverse", ctypes.c_void_p),
+            ("CommonPrefixWith", ctypes.c_void_p),
+            ("RelativePathTo", ctypes.c_void_p),
+            ("GetDisplayName", ctypes.c_void_p),
+            ("ParseDisplayName", ctypes.c_void_p),
+            ("IsSystemMoniker", ctypes.c_void_p),
+        ]
+
+    ICreateDevEnum._fields_ = [("lpVtbl", ctypes.POINTER(ICreateDevEnumVtbl))]
+    IEnumMoniker._fields_ = [("lpVtbl", ctypes.POINTER(IEnumMonikerVtbl))]
+    IMoniker._fields_ = [("lpVtbl", ctypes.POINTER(IMonikerVtbl))]
+
+    ole32 = ctypes.OleDLL("ole32")
+    ole32.CoInitializeEx.argtypes = [ctypes.c_void_p, wintypes.DWORD]
+    ole32.CoInitializeEx.restype = HRESULT
+    ole32.CoUninitialize.argtypes = []
+    ole32.CoUninitialize.restype = None
+    ole32.CoCreateInstance.argtypes = [
+        ctypes.POINTER(GUID),
+        ctypes.c_void_p,
+        wintypes.DWORD,
+        ctypes.POINTER(GUID),
+        ctypes.POINTER(ctypes.c_void_p),
+    ]
+    ole32.CoCreateInstance.restype = HRESULT
+    ole32.CreateBindCtx.argtypes = [wintypes.DWORD, ctypes.POINTER(ctypes.c_void_p)]
+    ole32.CreateBindCtx.restype = HRESULT
+    ole32.CoTaskMemFree.argtypes = [ctypes.c_void_p]
+    ole32.CoTaskMemFree.restype = None
+
+    COINIT_APARTMENTTHREADED = 0x2
+    CLSCTX_INPROC_SERVER = 0x1
+
+    init_hr = ole32.CoInitializeEx(None, COINIT_APARTMENTTHREADED)
+    initialized = init_hr in (0, 1)
+    if init_hr < 0:
+        return []
+
+    devices: List[str] = []
+    create_dev_enum = ctypes.POINTER(ICreateDevEnum)()
+    try:
+        dev_enum_void = ctypes.c_void_p()
+        hr = ole32.CoCreateInstance(
+            ctypes.byref(CLSID_SystemDeviceEnum),
+            None,
+            CLSCTX_INPROC_SERVER,
+            ctypes.byref(IID_ICreateDevEnum),
+            ctypes.byref(dev_enum_void),
+        )
+        if hr < 0:
+            return []
+
+        create_dev_enum = ctypes.cast(dev_enum_void, ctypes.POINTER(ICreateDevEnum))
+        create_enum_fn = ctypes.WINFUNCTYPE(
+            HRESULT,
+            ctypes.c_void_p,
+            ctypes.POINTER(GUID),
+            ctypes.POINTER(ctypes.POINTER(IEnumMoniker)),
+            wintypes.DWORD,
+        )(create_dev_enum.contents.lpVtbl.contents.CreateClassEnumerator)
+
+        enum_moniker = ctypes.POINTER(IEnumMoniker)()
+        hr = create_enum_fn(create_dev_enum, ctypes.byref(CLSID_VideoInputDeviceCategory), ctypes.byref(enum_moniker), 0)
+        if hr != 0:
+            return []
+
+        try:
+            release_enum = None
+            next_fn = ctypes.WINFUNCTYPE(
+                HRESULT,
+                ctypes.c_void_p,
+                ctypes.c_ulong,
+                ctypes.POINTER(ctypes.POINTER(IMoniker)),
+                ctypes.POINTER(ctypes.c_ulong),
+            )(enum_moniker.contents.lpVtbl.contents.Next)
+            release_enum = ctypes.WINFUNCTYPE(ctypes.c_ulong, ctypes.c_void_p)(enum_moniker.contents.lpVtbl.contents.Release)
+
+            bind_ctx = ctypes.c_void_p()
+            hr = ole32.CreateBindCtx(0, ctypes.byref(bind_ctx))
+            if hr < 0:
+                return []
+
+            try:
+                release_bind = None
+                if bind_ctx:
+                    vtbl = ctypes.cast(bind_ctx, ctypes.POINTER(ctypes.POINTER(ctypes.c_void_p)))
+                    release_bind = ctypes.WINFUNCTYPE(ctypes.c_ulong, ctypes.c_void_p)(vtbl.contents[2])
+
+                get_display = None
+                release_moniker = None
+
+                while True:
+                    fetched = ctypes.c_ulong()
+                    moniker = ctypes.POINTER(IMoniker)()
+                    hr = next_fn(enum_moniker, 1, ctypes.byref(moniker), ctypes.byref(fetched))
+                    if hr != 0 or fetched.value == 0:
+                        break
+
+                    try:
+                        vtbl = moniker.contents.lpVtbl.contents
+                        if get_display is None:
+                            get_display = ctypes.WINFUNCTYPE(
+                                HRESULT,
+                                ctypes.c_void_p,
+                                ctypes.c_void_p,
+                                ctypes.c_void_p,
+                                ctypes.POINTER(ctypes.c_void_p),
+                            )(vtbl.GetDisplayName)
+                        if release_moniker is None:
+                            release_moniker = ctypes.WINFUNCTYPE(ctypes.c_ulong, ctypes.c_void_p)(vtbl.Release)
+
+                        name_ptr = ctypes.c_void_p()
+                        hr = get_display(moniker, bind_ctx, None, ctypes.byref(name_ptr))
+                        if hr == 0 and name_ptr.value:
+                            try:
+                                devices.append(ctypes.wstring_at(name_ptr.value))
+                            finally:
+                                ole32.CoTaskMemFree(name_ptr)
+                    finally:
+                        if release_moniker is not None and moniker:
+                            release_moniker(moniker)
+
+                if release_bind is not None and bind_ctx:
+                    release_bind(bind_ctx)
+            finally:
+                if enum_moniker and release_enum is not None:
+                    release_enum(enum_moniker)
+        finally:
+            if create_dev_enum:
+                release_create = ctypes.WINFUNCTYPE(ctypes.c_ulong, ctypes.c_void_p)(create_dev_enum.contents.lpVtbl.contents.Release)
+                release_create(create_dev_enum)
+    finally:
+        if initialized:
+            ole32.CoUninitialize()
+
+    return devices
+
+
+def _windows_pnp_name_map() -> Dict[str, str]:
+    cmd = [
+        "powershell",
+        "-NoProfile",
+        "-Command",
+        "(Get-CimInstance Win32_PnPEntity) | Where-Object { $_.PNPClass -eq 'Camera' -or $_.Service -eq 'usbvideo' -or $_.ClassGuid -eq '{e5323777-f976-4f5b-9b55-b94699c46e44}' } | Select-Object Name, PNPDeviceID | ConvertTo-Json -Compress",
+    ]
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=5, check=True)
+    except (FileNotFoundError, subprocess.SubprocessError):
+        return {}
+
+    output = proc.stdout.strip()
+    if not output:
+        return {}
+
+    try:
+        data = json.loads(output)
+    except json.JSONDecodeError:
+        return {}
+
+    mapping: Dict[str, str] = {}
+    entries = data if isinstance(data, list) else [data]
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        name = entry.get("Name")
+        pnp_id = entry.get("PNPDeviceID")
+        if not name or not pnp_id:
+            continue
+        mapping[str(pnp_id).upper()] = str(name)
+    return mapping
+
+
+def _enumerate_cameras_windows() -> List[Tuple[int, str]]:
+    display_names = _win32_directshow_display_names()
+    pnp_map = _windows_pnp_name_map()
+
+    devices: List[Tuple[int, str]] = []
+    for idx, display_name in enumerate(display_names):
+        pnp_id = _extract_windows_pnp_id(display_name)
+        friendly = pnp_map.get(pnp_id or "") if pnp_id else None
+        if not friendly:
+            friendly = pnp_map.get(display_name.upper())
+        if not friendly:
+            friendly = display_name
+        devices.append((idx, friendly))
+
+    if devices:
+        return devices
+
+    if pnp_map:
+        return [(i, name) for i, name in enumerate(pnp_map.values())]
+
+    return []
+
+
+def _enumerate_cameras_macos() -> List[Tuple[int, str]]:
+    cmd = ["system_profiler", "SPCameraDataType", "-json"]
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=5, check=True)
+    except (FileNotFoundError, subprocess.SubprocessError):
+        return []
+
+    try:
+        data = json.loads(proc.stdout or "{}")
+    except json.JSONDecodeError:
+        return []
+
+    cameras = data.get("SPCameraDataType", [])
+    names: List[str] = []
+    for cam in cameras:
+        name = cam.get("_name") or cam.get("spcamera_model_id")
+        if name:
+            names.append(str(name))
+    return [(i, name) for i, name in enumerate(names)]
+
+
+def _probe_opencv_indices(max_probes: int) -> List[int]:
+    try:
+        import cv2  # type: ignore
+    except Exception:
+        return []
+
+    found: List[int] = []
+    for idx in range(max_probes):
+        cap = cv2.VideoCapture(idx)
+        if cap is None:
+            continue
+        try:
+            if cap.isOpened():
+                found.append(idx)
+        finally:
+            cap.release()
+    return found
+
+
+def _merge_with_probed_indices(
+    devices: List[Tuple[int, str]],
+    probed: Iterable[int],
+) -> List[Tuple[int, str]]:
+    probed_list = list(dict.fromkeys(int(i) for i in probed if isinstance(i, int)))
+    if not probed_list:
+        return devices
+
+    used: set[int] = set()
+    merged: List[Tuple[int, str]] = []
+
+    sequential = all(idx == i for i, (idx, _) in enumerate(devices))
+    assigned_from_sequential = 0
+    if sequential:
+        for actual_idx, (_, name) in zip(probed_list, devices):
+            used.add(actual_idx)
+            merged.append((actual_idx, name))
+            assigned_from_sequential += 1
+
+    remaining_devices = devices[assigned_from_sequential:]
+    remaining_probed = [idx for idx in probed_list if idx not in used]
+
+    fallback_iter = (idx for idx in remaining_probed if idx not in used)
+
+    for idx, name in remaining_devices:
+        assigned = int(idx)
+        if assigned not in probed_list:
+            assigned = next(fallback_iter, assigned)
+        used.add(assigned)
+        merged.append((assigned, name))
+
+    for idx in probed_list:
+        if idx not in used:
+            merged.append((idx, f"Camera {idx}"))
+
+    merged.sort(key=lambda item: item[0])
+    return merged
+
+
+def enumerate_cameras() -> List[Tuple[int, str]]:
+    try:
+        system = platform.system().lower()
+    except Exception:
+        system = sys.platform.lower()
+
+    if system.startswith("linux"):
+        devices = _enumerate_cameras_linux()
+        merge_with_probes = True
+    elif system.startswith("windows"):
+        devices = _enumerate_cameras_windows()
+        merge_with_probes = True
+    elif system.startswith("darwin") or system.startswith("mac"):
+        devices = _enumerate_cameras_macos()
+        merge_with_probes = False
+    else:
+        devices = []
+        merge_with_probes = False
+
+    devices = [(int(idx), str(name)) for idx, name in devices]
+
+    # Deduplicate while preserving order
+    seen = set()
+    unique_devices: List[Tuple[int, str]] = []
+    for idx, name in devices:
+        key = (idx, name)
+        if key in seen:
+            continue
+        seen.add(key)
+        unique_devices.append((idx, name))
+
+    max_probe = max((idx for idx, _ in unique_devices), default=-1)
+    max_probe = max(8, max_probe + 4)
+    probed = _probe_opencv_indices(max_probe)
+    if merge_with_probes:
+        unique_devices = _merge_with_probed_indices(unique_devices, probed)
+    else:
+        existing_indices = {idx for idx, _ in unique_devices}
+        for idx in probed:
+            idx = int(idx)
+            if idx in existing_indices:
+                continue
+            unique_devices.append((idx, f"Camera {idx}"))
+            existing_indices.add(idx)
+    return unique_devices
+
+
+CAMERA_CHOICES: List[Tuple[int, str]] = enumerate_cameras()
 
 
 # 각 탭 상단에 간단한 설명을 보여줍니다.
@@ -47,7 +513,7 @@ FEATURE_HELP: Dict[str, str] = {
 SCHEMA: Dict[str, List[FieldSpec]] = {
     "Source": [
         FieldSpec("src", "Video path (empty=webcam)", "file", "", help="동영상 파일을 선택하거나 비워두면 웹캠을 사용합니다."),
-        FieldSpec("cam", "Camera index", "int", 1),
+        FieldSpec("cam", "Camera device", "camera", 0),
         FieldSpec("backend", "OpenCV backend", "choice", "ds", choices=["ds", "ms", "auto"]),
         FieldSpec("cap_fps", "Capture FPS (0=auto)", "float", 0.0),
         FieldSpec("mjpg", "Use MJPG", "bool", False),
@@ -210,6 +676,40 @@ def _build_gui_and_get_values(defaults: dict) -> dict:
             om.pack(side="left", fill="x", expand=True)
             widgets.append(om)
 
+        elif spec.type == "camera":
+            choices = CAMERA_CHOICES
+            if choices:
+                var = tk.StringVar()
+                display: List[str] = []
+                mapping: Dict[str, int] = {}
+                for idx, name in choices:
+                    label = f"[{idx}] {name}" if name else f"Camera {idx}"
+                    display.append(label)
+                    mapping[label] = idx
+
+                default_idx = int(val) if isinstance(val, int) else int(spec.default)
+                default_label = None
+                for label, idx in mapping.items():
+                    if idx == default_idx:
+                        default_label = label
+                        break
+                if default_label is None and display:
+                    default_label = display[0]
+                if default_label:
+                    var.set(default_label)
+
+                cb = ttk.Combobox(row, textvariable=var, values=display)
+                cb.pack(side="left", fill="x", expand=True)
+                widgets.append(cb)
+                registry[spec.key] = {"var": var, "widgets": widgets, "type": spec.type, "choices_map": mapping}
+                return
+
+            # fallback: manual entry
+            var = tk.StringVar(value=str(val))
+            ent = ttk.Entry(row, textvariable=var)
+            ent.pack(side="left", fill="x", expand=True)
+            widgets.append(ent)
+
         elif spec.type == "file":
             var = tk.StringVar(value=str(val))
             ent = ttk.Entry(row, textvariable=var)
@@ -335,6 +835,20 @@ def _build_gui_and_get_values(defaults: dict) -> dict:
                             result[spec.key] = float(val)
                         else:
                             result[spec.key] = val
+                    elif spec.type == "camera":
+                        mapping = info.get("choices_map")
+                        if mapping:
+                            sel = var.get()
+                            idx = mapping.get(sel)
+                            if idx is None:
+                                with contextlib.suppress(ValueError):
+                                    idx = int(sel)
+                            if idx is None:
+                                idx = int(spec.default)
+                            result[spec.key] = int(idx)
+                        else:
+                            s = var.get()
+                            result[spec.key] = int(s) if s != "" else int(spec.default)
                     else:
                         s = var.get()
                         if spec.type == "int":


### PR DESCRIPTION
## Summary
- enumerate Windows cameras using DirectShow to preserve the actual index ordering
- match DirectShow device identifiers to friendly PNP names so the GUI shows readable labels bound to the right index
- align Windows-friendly camera names with the OpenCV indices discovered by probing so selections launch the intended device
- keep PowerShell enumeration as a fallback when DirectShow probing fails

## Testing
- python -m compileall ui/gui_startup.py

------
https://chatgpt.com/codex/tasks/task_e_68d372319fb88322b2a203012f1af472