### PR TITLE
Optimize GPU concurrency and warm-up

### DIFF
--- a/pipeline/loop.py
+++ b/pipeline/loop.py
@@ -24,7 +24,16 @@ from .frame_ops import (
     run_rvm_on_roi_or_full,
     show_preview,
 )
-from .setup import build_models, build_sender_or_exit, init_ndi_or_exit, open_capture, prepare_grading, prepare_preview, probe_source_size_or_exit
+from .setup import (
+    build_models,
+    build_sender_or_exit,
+    init_ndi_or_exit,
+    open_capture,
+    prepare_grading,
+    prepare_preview,
+    probe_source_size_or_exit,
+    warmup_cuda_kernels,
+)
 
 
 def build_context(args: argparse.Namespace, stop_event: Optional[threading.Event] = None) -> RunContext:
@@ -44,6 +53,7 @@ def build_context(args: argparse.Namespace, stop_event: Optional[threading.Event
     center = lazy.CenterTracker(out_w, out_h, args.center_smooth, args.center_deadzone)
 
     device, pose, rvm, hands = build_models(args)
+    warmup_cuda_kernels(args, device, pose, rvm, cam_w, cam_h)
     sender = build_sender_or_exit(args, out_w, out_h)
     prepare_preview(args, out_w, out_h)
 

--- a/pose_components/pose_detector.py
+++ b/pose_components/pose_detector.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from typing import Optional, Tuple
+import contextlib
 import cv2, torch
 import numpy as np
 from ultralytics import YOLO
@@ -8,6 +9,7 @@ class PoseDetector:
     def __init__(self, weights: str, device: torch.device, use_half: bool = False, conf: float = 0.35,
                  imgsz: int = 640):
         self.model = YOLO(weights).to(device)
+        self.device = device
         try:
             self.model.fuse()
         except Exception:
@@ -21,6 +23,7 @@ class PoseDetector:
         self.conf = conf
         self.imgsz = imgsz
         self.dev_arg = 0 if device.type == "cuda" else "cpu"
+        self.stream = torch.cuda.Stream(device=device) if device.type == "cuda" else None
 
     def predict_downscaled(self, frame_bgr: np.ndarray, scale: float
                            ) -> Tuple[Optional[np.ndarray], Optional[np.ndarray]]:
@@ -43,26 +46,35 @@ class PoseDetector:
         return xy, conf_small
 
     def _predict_raw(self, frame_bgr: np.ndarray) -> Tuple[Optional[np.ndarray], Optional[np.ndarray]]:
-        res = self.model.predict(
-            source=frame_bgr,
-            device=self.dev_arg,
-            stream=False,
-            show=False,
-            conf=self.conf,
-            imgsz=self.imgsz,
-            verbose=False,
-            half=self.use_half
+        stream = self.stream
+        stream_ctx = (
+            torch.cuda.stream(stream) if stream is not None else contextlib.nullcontext()
         )
+        with stream_ctx:
+            res = self.model.predict(
+                source=frame_bgr,
+                device=self.dev_arg,
+                stream=False,
+                show=False,
+                conf=self.conf,
+                imgsz=self.imgsz,
+                verbose=False,
+                half=self.use_half,
+            )
         if not res:
             return None, None
         kps = res[0].keypoints
         if kps is None or len(kps) == 0:
             return None, None
 
-        xy_all = kps.xy.cpu().numpy()  # (N,17,2)
+        xy_tensor = kps.xy.detach()
+        if stream is not None:
+            torch.cuda.current_stream(self.device).wait_stream(stream)
+        xy_all = xy_tensor.to("cpu", non_blocking=bool(stream)).numpy()  # (N,17,2)
         conf_all = None
         if hasattr(kps, "confidence") and kps.confidence is not None:
-            conf_all = kps.confidence.cpu().numpy()
+            conf_tensor = kps.confidence.detach()
+            conf_all = conf_tensor.to("cpu", non_blocking=bool(stream)).numpy()
             if conf_all.ndim == 3 and conf_all.shape[-1] == 1:
                 conf_all = conf_all[..., 0]
         return xy_all, conf_all

--- a/pose_components/rvm_wrapper.py
+++ b/pose_components/rvm_wrapper.py
@@ -1,8 +1,12 @@
-﻿from __future__ import annotations
-import cv2, torch
+from __future__ import annotations
+
+import contextlib
+import cv2
+import torch
 import numpy as np
 
-def pad_to_multiple(img: np.ndarray, m: int = 8) -> tuple[np.ndarray, tuple[int,int,int,int]]:
+
+def pad_to_multiple(img: np.ndarray, m: int = 8) -> tuple[np.ndarray, tuple[int, int, int, int]]:
     """오른쪽/아래로만 패딩해서 (H,W)를 m의 배수로 맞춘다. pad=(top,bottom,left,right)"""
     h, w = img.shape[:2]
     H = ((h + m - 1) // m) * m
@@ -13,8 +17,10 @@ def pad_to_multiple(img: np.ndarray, m: int = 8) -> tuple[np.ndarray, tuple[int,
     img2 = cv2.copyMakeBorder(img, 0, pad_b, 0, pad_r, cv2.BORDER_REPLICATE)
     return img2, (0, pad_b, 0, pad_r)
 
+
 class RVM:
     """Robust Video Matting wrapper (torch hub) with FP16 + safe state handling."""
+
     def __init__(self, device: torch.device, half: bool = False):
         self.model = torch.hub.load("PeterL1n/RobustVideoMatting", "mobilenetv3").to(device).eval()
         self.device = device
@@ -23,7 +29,8 @@ class RVM:
         if self.use_half:
             self.model.half()
         # 마지막 입력 텐서 크기(패딩 적용 후 기준)
-        self._last_hw: tuple[int,int] | None = None
+        self._last_hw: tuple[int, int] | None = None
+        self.stream = torch.cuda.Stream(device=device) if device.type == "cuda" else None
 
     def reset_states(self) -> None:
         self.r1 = self.r2 = self.r3 = self.r4 = None
@@ -40,9 +47,9 @@ class RVM:
         bgr: np.ndarray,
         downsample: float = 0.25,
         *,
-        enforce_stride: bool = True,     # True면 8배수 패딩
+        enforce_stride: bool = True,  # True면 8배수 패딩
         stride: int = 8,
-        reset_on_resize: bool = True     # 크기 변하면 state 리셋
+        reset_on_resize: bool = True,  # 크기 변하면 state 리셋
     ) -> np.ndarray:
         """
         반환: uint8 알파 (H,W), [0..255]
@@ -50,28 +57,34 @@ class RVM:
         """
         # 0) (선택) stride 배수로 패딩
         src = bgr
-        pad = (0,0,0,0)
+        pad = (0, 0, 0, 0)
         if enforce_stride:
             src, pad = pad_to_multiple(bgr, m=stride)
 
         H, W = src.shape[:2]
         self._ensure_state_for(H, W, reset_on_resize)
 
-        # 1) RGB float[0,1] 텐서
-        src_rgb = cv2.cvtColor(src, cv2.COLOR_BGR2RGB)
-        t = torch.from_numpy(src_rgb).permute(2, 0, 1).unsqueeze(0).to(self.device)
-        t = t.to(torch.float16 if self.use_half else torch.float32).div_(255.0)
+        stream = self.stream
+        stream_ctx = torch.cuda.stream(stream) if stream is not None else contextlib.nullcontext()
+        with stream_ctx:
+            # 1) RGB float[0,1] 텐서
+            src_rgb = cv2.cvtColor(src, cv2.COLOR_BGR2RGB)
+            t = torch.from_numpy(src_rgb).permute(2, 0, 1).unsqueeze(0).to(self.device)
+            t = t.to(torch.float16 if self.use_half else torch.float32).div_(255.0)
 
-        # 2) 추론
-        fgr, pha, self.r1, self.r2, self.r3, self.r4 = self.model(
-            t, self.r1, self.r2, self.r3, self.r4, downsample_ratio=float(downsample)
-        )
+            # 2) 추론
+            _, pha, self.r1, self.r2, self.r3, self.r4 = self.model(
+                t, self.r1, self.r2, self.r3, self.r4, downsample_ratio=float(downsample)
+            )
 
-        # 3) numpy 변환
-        alpha_pad = (pha[0, 0].clamp_(0, 1).mul_(255).byte().cpu().numpy())
+            alpha_pad_tensor = pha[0, 0].clamp_(0, 1).mul_(255).byte()
+
+        if stream is not None:
+            torch.cuda.current_stream(self.device).wait_stream(stream)
+        alpha_pad = alpha_pad_tensor.to("cpu", non_blocking=bool(stream)).numpy()
 
         # 4) 패딩을 되돌려 원래 크기로 크롭
-        if pad != (0,0,0,0):
+        if pad != (0, 0, 0, 0):
             h, w = bgr.shape[:2]
             alpha = alpha_pad[:h, :w]
         else:


### PR DESCRIPTION
## Summary
- add dedicated CUDA streams to the pose detector and RVM matting wrapper so their kernels run off the default stream and copies happen with non-blocking transfers
- introduce a CUDA warm-up helper in the pipeline setup to prime cuDNN/cuBLAS on first run while keeping the matting state clean
- hook the warm-up into context creation after probing the camera and allow opting out with a flag

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d5ec500ae083229580c4381905845d