### PR TITLE
Rename mirror controls to horizontal flip

### DIFF
--- a/app/args.py
+++ b/app/args.py
@@ -35,7 +35,10 @@ def build_parser() -> argparse.ArgumentParser:
     ap.add_argument("--queue-len", type=int, default=1)
     ap.add_argument("--cap-fps", type=float, default=0.0)
     ap.add_argument("--mjpg", action="store_true")
-    ap.add_argument("--mirror", default=True, action="store_true")
+    ap.add_argument("--horizontal-flip", dest="horizontal_flip", default=True, action="store_true",
+                    help="Flip the output horizontally")
+    ap.add_argument("--flip-vertical", dest="flip_vertical", action="store_true", default=False,
+                    help="Flip the output vertically")
 
     ap.add_argument("--hands", action="store_true", default=False)
     ap.add_argument("--hands-max", type=int, default=2)

--- a/pipeline/loop.py
+++ b/pipeline/loop.py
@@ -16,7 +16,7 @@ from .frame_ops import (
     compute_bbox_canvas,
     compute_center_and_transform,
     log_fps,
-    mirror_if_needed,
+    apply_output_flips_if_needed,
     prepare_coordinates_and_hands,
     rotate_if_needed,
     run_hands_every,
@@ -139,8 +139,10 @@ def run_loop(ctx: RunContext) -> None:
             xy_send, conf_send, hands_send = prepare_coordinates_and_hands(ctx, M, xy_use_src, conf_use, hands_src, bbox_canvas)
             prof.mark("prep")
 
-            frame_rgba, xy_send, hands_send, bbox_canvas = mirror_if_needed(ctx, frame_rgba, xy_send, hands_send, bbox_canvas)
-            prof.mark("mirror")
+            frame_rgba, xy_send, hands_send, bbox_canvas = apply_output_flips_if_needed(
+                ctx, frame_rgba, xy_send, hands_send, bbox_canvas
+            )
+            prof.mark("flip")
 
             frame_to_send = frame_rgba if frame_rgba.flags["C_CONTIGUOUS"] else np.ascontiguousarray(frame_rgba)
             ctx.udp.send(xy_send, conf_send, hands_send)

--- a/ui/gui_startup.py
+++ b/ui/gui_startup.py
@@ -519,7 +519,8 @@ SCHEMA: Dict[str, List[FieldSpec]] = {
         FieldSpec("cap_fps", "Capture FPS (0=auto)", "float", 0.0),
         FieldSpec("mjpg", "Use MJPG", "bool", False),
         FieldSpec("rotate", "Rotate CW", "choice", 270, choices=[0, 90, 180, 270]),
-        FieldSpec("mirror", "Mirror output", "bool", True),
+        FieldSpec("horizontal_flip", "Flip horizontally", "bool", True),
+        FieldSpec("flip_vertical", "Flip vertically", "bool", False),
         FieldSpec("ndi_follow_camera", "NDI follow camera size", "bool", False, help=FEATURE_HELP["ndi_follow_camera"]),
     ],
     "Output": [


### PR DESCRIPTION
## Summary
- rename the CLI and GUI options from mirror to horizontal flip
- update the output flip routine and loop to use the new naming

## Testing
- python -m compileall app/args.py pipeline/frame_ops.py ui/gui_startup.py

------
https://chatgpt.com/codex/tasks/task_e_68d64aa8a40c8322af3005f087bcf18b