### PR TITLE
Add progress reporting during pipeline initialization

### DIFF
--- a/pipeline/runner.py
+++ b/pipeline/runner.py
@@ -27,7 +27,11 @@ class PipelineRunner:
             def worker() -> None:
                 ctx = None
                 try:
-                    ctx = build_context(args, stop_event=stop_event)
+                    ctx = build_context(
+                        args,
+                        stop_event=stop_event,
+                        progress=self.app.queue_status,
+                    )
                     with self._lock:
                         self.ctx = ctx
                     self.app.on_pipeline_running_threadsafe()


### PR DESCRIPTION
## Summary
- add an optional progress callback to the pipeline context builder so initialization steps can be surfaced
- show initialization status updates in the GUI control panel and print them for CLI runs

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d65151b73483228feb7c9845698937