### PR TITLE
Send UDP pose packets only when new inference is available

### DIFF
--- a/pipeline/frame_ops.py
+++ b/pipeline/frame_ops.py
@@ -25,6 +25,7 @@ def rotate_if_needed(frame_bgr, rot: int):
 def run_pose_every(ctx: RunContext, caches: Caches, frame_bgr):
     np = lazy.np
     pose_worker = getattr(ctx, "pose_worker", None)
+    pose_updated = False
 
     if pose_worker is not None:
         if (caches.frames % max(1, ctx.args.pose_every)) == 0:
@@ -37,6 +38,7 @@ def run_pose_every(ctx: RunContext, caches: Caches, frame_bgr):
                 caches.last_pose_result_id = pose_id
                 caches.last_xy_all_src = xy_all_src
                 caches.last_conf_all = conf_all
+                pose_updated = True
 
         xy_all_src = caches.last_xy_all_src
         conf_all = caches.last_conf_all
@@ -47,6 +49,10 @@ def run_pose_every(ctx: RunContext, caches: Caches, frame_bgr):
             if xy_all_src is not None:
                 caches.last_xy_all_src = xy_all_src
                 caches.last_conf_all = conf_all
+            else:
+                caches.last_xy_all_src = None
+                caches.last_conf_all = None
+            pose_updated = True
         else:
             xy_all_src = caches.last_xy_all_src
             conf_all = caches.last_conf_all
@@ -79,7 +85,7 @@ def run_pose_every(ctx: RunContext, caches: Caches, frame_bgr):
     else:
         bbox_src_debug = caches.last_bbox_src_debug
 
-    return xy_use_src, conf_use, bbox_src_debug
+    return xy_use_src, conf_use, bbox_src_debug, pose_updated
 
 
 def run_hands_every(ctx: RunContext, caches: Caches, frame_bgr, bbox_src_debug: Optional[Tuple[int, int, int, int]]):

--- a/pipeline/loop.py
+++ b/pipeline/loop.py
@@ -138,7 +138,7 @@ def run_loop(ctx: RunContext) -> None:
 
             caches.frames += 1
 
-            xy_use_src, conf_use, bbox_src_debug = run_pose_every(ctx, caches, frame_bgr)
+            xy_use_src, conf_use, bbox_src_debug, pose_updated = run_pose_every(ctx, caches, frame_bgr)
             prof.mark("pose")
 
             hands_src = run_hands_every(ctx, caches, frame_bgr, bbox_src_debug)
@@ -171,7 +171,8 @@ def run_loop(ctx: RunContext) -> None:
             prof.mark("flip")
 
             frame_to_send = frame_rgba if frame_rgba.flags["C_CONTIGUOUS"] else np.ascontiguousarray(frame_rgba)
-            ctx.udp.send(xy_send, conf_send, hands_send)
+            if pose_updated:
+                ctx.udp.send(xy_send, conf_send, hands_send)
             ctx.sender.send_rgba(frame_to_send)
             prof.mark("io")
 


### PR DESCRIPTION
## Summary
- track whether the latest pose inference result is new or cached
- send UDP pose packets only when new inference data arrives to avoid duplicates

## Testing
- python -m compileall pipeline

------
https://chatgpt.com/codex/tasks/task_e_68d676a62fe08322be00466b203d9c0e